### PR TITLE
add global availability for scss variables

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4,9 +4,6 @@ import App from './App.vue'
 import router from './router'
 import store from './store'
 
-import 'bootstrap/dist/css/bootstrap.css'
-import 'bootstrap-vue/dist/bootstrap-vue.css'
-
 Vue.use(BootstrapVue)
 
 Vue.config.productionTip = false

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -1,0 +1,2 @@
+@import "utilities/variables";
+@import "node_modules/bootstrap/scss/bootstrap.scss";

--- a/src/scss/utilities/_variables.scss
+++ b/src/scss/utilities/_variables.scss
@@ -1,0 +1,2 @@
+// overwrite bootstrap variables here
+$primary: #005cff;

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -32,6 +32,9 @@ export default {
 
 <style lang="scss">
 #Home {
+  h1 {
+    color: $primary;
+  }
   .avatar {
     img {
       border-radius: 75px;

--- a/vue.config.js
+++ b/vue.config.js
@@ -3,4 +3,13 @@ module.exports = {
     port: '8080',
   },
   lintOnSave: true,
+  css: {
+    loaderOptions: {
+      sass: {
+        prependData: `
+          @import "@/scss/style.scss";
+        `,
+      },
+    },
+  },
 }


### PR DESCRIPTION
Bootstrap styles are now imported by scss. I createtd a _variables.scss file to override the default Bootstrap variables. Variables are globally available.